### PR TITLE
Reformat Support Bot Slack message (2nd attempt)

### DIFF
--- a/src/logic/index.js
+++ b/src/logic/index.js
@@ -205,16 +205,17 @@ module.exports = function (logger) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `*Need help from*\n${team.display}`,
-      },
-    };
-
-    blocks[3] = {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `Assigned to: ${onCallUser}`,
+        text: `*Assigned to: ${onCallUser}* (${team.display})`,
         verbatim: false,
+      },
+      accessory: {
+        type: 'button',
+        text: {
+          type: 'plain_text',
+          text: 'Reassign Ticket',
+        },
+        action_id: 'reassign_ticket',
+        value: ticketId,
       },
     };
 

--- a/src/ui/messages.js
+++ b/src/ui/messages.js
@@ -18,7 +18,7 @@ const buildSupportResponse = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: mention ? `*Assigned to: ${mention}* (${team})` : `*Assigned to: ${team}*`,
+        text: mention ? `*Assigned to: ${mention}* (${selectedTeam})\n` : `*Assigned to: ${team}*\n`,
       },
       accessory: {
         type: 'button',

--- a/src/ui/messages.js
+++ b/src/ui/messages.js
@@ -11,7 +11,14 @@ const buildSupportResponse = (
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `Hey there <@${userId}>! We've received your Platform support request.`,
+        text: `From *<@${userId}>*: ${summaryDescription}`,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: mention ? `*Assigned to: ${mention}* (${team})` : `*Assigned to: ${team}*`,
       },
       accessory: {
         type: 'button',
@@ -21,27 +28,6 @@ const buildSupportResponse = (
         },
         action_id: 'reassign_ticket',
         value: ticketId,
-      },
-    },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*Need help from*\n${selectedTeam}`,
-      },
-    },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `*Summary*\n${summaryDescription}`,
-      },
-    },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: mention ? `Assigned to: ${mention}` : `Assigned to: ${team}`,
       },
     },
   ];

--- a/test/ui/messages.test.js
+++ b/test/ui/messages.test.js
@@ -21,10 +21,8 @@ describe('ui/messages', () => {
     );
 
     expect(response[0].text.text).to.equal(
-      "Hey there <@alex.yip>! We've received your Platform support request."
+      "From *<@alex.yip>*: I need a PR Reviewed"
     );
-    expect(response[1].text.text).to.equal('*Need help from*\nFE Tools');
-    expect(response[2].text.text).to.equal('*Summary*\nI need a PR Reviewed');
-    expect(response[3].text.text).to.equal('Assigned to: <@alex.yip>');
+    expect(response[1].text.text).to.equal('*Assigned to: <@alex.yip>* (FE Tools)\n');
   });
 });


### PR DESCRIPTION
I figured out what caused Support Bot to crash yesterday, that should be fixed in this version. It had to do with the function that runs when the ticket gets reassigned looking for message blocks that no longer exist in this redesign. I have tested the Reassign Ticket functionality locally extensively.

This is what the message will look like now:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/12739849/134534731-03659dff-8535-487d-8b6f-e6ea4b48cb60.png">

And just because I wanted to see what it would look like, here is what two messages look like when they are added one right after the other:
<img width="686" alt="image" src="https://user-images.githubusercontent.com/12739849/134534929-ff73a98e-821d-42b7-a9b2-f6f3e1a98fa4.png">
