### PR TITLE
use team display names in dropdown menus

### DIFF
--- a/src/api/google/index.js
+++ b/src/api/google/index.js
@@ -90,7 +90,7 @@ module.exports = function (logger) {
 
     return rows.map((row) => {
       return {
-        text: row.Title,
+        text: row.Display,
         value: row.Id,
       };
     });

--- a/test/api/google/index.test.js
+++ b/test/api/google/index.test.js
@@ -16,8 +16,8 @@ describe('api/google', () => {
     sinon.stub(sheets, 'getResponsesSheet').resolves(obj);
 
     sinon.stub(sheets, 'getTeamsSheetRows').resolves([
-      { Title: 'Frontend Tools', Id: 'FE' },
-      { Title: 'Backend Tools', Id: 'BE' },
+      { Display: 'Frontend Tools', Id: 'FE' },
+      { Display: 'Backend Tools', Id: 'BE' },
     ]);
 
     sheets.getGoogleSheet.callThrough();
@@ -44,7 +44,7 @@ describe('api/google', () => {
       const result = await sheets.getTeamById(2);
 
       expect(result).to.eql({
-        Title: 'Backend Tools',
+        Display: 'Backend Tools',
         Id: 'BE',
       });
     });


### PR DESCRIPTION
Currently support bot shows abbreviated team names in the dropdown menus when creating and reassigning a support ticket. This change makes it so that support bot will show the full team names in the dropdowns.

The support modal will now look like this:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/12739849/134582618-ac2ed8d6-e676-4ae8-b16a-fa0ea51c2f49.png">

And the Reassign Ticket modal will now look like this:
<img width="514" alt="image" src="https://user-images.githubusercontent.com/12739849/134582642-f0d97cba-33bf-43ba-9534-20df86a1f703.png">
