### PR TITLE
add FirstReplyTimeEST to responses spreadsheet

### DIFF
--- a/src/api/google/index.js
+++ b/src/api/google/index.js
@@ -163,8 +163,12 @@ module.exports = function (logger) {
 
     const row = rows.find((row) => row.MessageId === messageId);
 
-    if (row && row.FirstReplyTimeUTC === '') {
-      row.FirstReplyTimeUTC = new Date(Date.now()).toISOString();
+    if (row && !row.FirstReplyTimeUTC) {
+      const dateTime = new Date(Date.now())
+      row.FirstReplyTimeUTC = dateTime.toISOString();
+      row.FirstReplyTimeEST = moment
+        .tz(dateTime, 'America/New_York')
+        .format('LLLL');
       await row.save();
     } else {
       logger.info(`Row not found for messageId: ${messageId}`);


### PR DESCRIPTION
Resolves #[29936](https://app.zenhub.com/workspaces/vsp---frontend-tools-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/29936).

The Service Design team requested that we add a column to the responses spreadsheet with a human readable version of the timestamp we add when the first response to a support ticket is recorded. This code is dependent on having that column present, and since not all of us have access to that [spreadsheet](https://docs.google.com/spreadsheets/d/1TItdfPMH_TiXEhgMKEqxIW2e5EaMKy4cHaBhaeQ7drU/edit#gid=0), I am adding a screenshot here to show that the column is there and has the correct header:
<img width="852" alt="image" src="https://user-images.githubusercontent.com/12739849/134733102-e3a07f2c-04ea-47e9-9b13-83be1869621b.png">