### PR TITLE
add FirstReplyTimeEST

### DIFF
--- a/src/api/google/index.js
+++ b/src/api/google/index.js
@@ -164,7 +164,11 @@ module.exports = function (logger) {
     const row = rows.find((row) => row.MessageId === messageId);
 
     if (row && row.FirstReplyTimeUTC === '') {
-      row.FirstReplyTimeUTC = new Date(Date.now()).toISOString();
+      const dateTime = new Date();
+      row.FirstReplyTimeUTC = dateTime;
+      row.FirstReplyTimeEST = moment
+        .tz(dateTime, 'America/New_York')
+        .format('LLLL');
       await row.save();
     } else {
       logger.info(`Row not found for messageId: ${messageId}`);


### PR DESCRIPTION
Trying this again. In my first attempt I changed the logic on line 166 to read `if (row && !row.FirstReplyTimeUTC)`, which worked locally, but may have caused Support Bot to crash in production.

In this version I have also changed the way the date is created to be more consistent with the DateTimeUTC and DateTimeEST fields, which report the time the request is created.