### PR TITLE
Change how date is created

### DIFF
--- a/src/api/google/index.js
+++ b/src/api/google/index.js
@@ -164,7 +164,7 @@ module.exports = function (logger) {
     const row = rows.find((row) => row.MessageId === messageId);
 
     if (row && row.FirstReplyTimeUTC === '') {
-      const dateTime = new Date();
+      const dateTime = new Date(Date.now());
       row.FirstReplyTimeUTC = dateTime.toISOString();
       row.FirstReplyTimeEST = moment
         .tz(dateTime, 'America/New_York')


### PR DESCRIPTION
This PR returns the `new Date()` call to `new Date(Date.now())` as it was originally.

I am attempting to fix an issue where support bot is seemingly randomly failing without any errors in the logs. It does not make sense that this change would fix it, but I'd like to try it. The failures started when [this PR](https://github.com/department-of-veterans-affairs/platform-support-slackbot/pull/12/files) was merged, so I'd like to try this before completely reverting the PR.